### PR TITLE
Add macOS Jellyfin browser app

### DIFF
--- a/MacJellyBrowser/Package.swift
+++ b/MacJellyBrowser/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MacJellyBrowser",
+    platforms: [
+        .macOS(.v11)
+    ],
+    products: [
+        .executable(name: "MacJellyBrowser", targets: ["MacJellyBrowser"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "MacJellyBrowser",
+            dependencies: []
+        )
+    ]
+)

--- a/MacJellyBrowser/README.md
+++ b/MacJellyBrowser/README.md
@@ -1,0 +1,16 @@
+# MacJellyBrowser
+
+A minimal SwiftUI app that combines a Jellyfin tab with a basic web browser.
+
+## Requirements
+- macOS 11 or later
+- Xcode with Swift development tools
+
+## Build & Run
+```
+cd MacJellyBrowser
+swift build
+swift run
+```
+
+The Jellyfin tab opens `http://localhost:8096` by default. Modify `main.swift` if your server runs on another URL.

--- a/MacJellyBrowser/Sources/MacJellyBrowser/WebView.swift
+++ b/MacJellyBrowser/Sources/MacJellyBrowser/WebView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import WebKit
+
+struct WebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        webView.load(URLRequest(url: url))
+    }
+}

--- a/MacJellyBrowser/Sources/MacJellyBrowser/main.swift
+++ b/MacJellyBrowser/Sources/MacJellyBrowser/main.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@main
+struct JellyBrowserApp: App {
+    @State private var address: String = "https://www.google.com"
+
+    var body: some Scene {
+        WindowGroup {
+            TabView {
+                WebView(url: URL(string: "http://localhost:8096")!)
+                    .tabItem { Text("Jellyfin") }
+                WebView(url: URL(string: address)!)
+                    .tabItem { Text("Browser") }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal Swift Package `MacJellyBrowser`
- use `WebView` to view Jellyfin and the web
- add instructions for building on macOS

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686a34bdd47883279b0e3221c0bd746c