### PR TITLE
Add simple WebDAV video browser app

### DIFF
--- a/WebDAVBrowser/README.md
+++ b/WebDAVBrowser/README.md
@@ -1,0 +1,18 @@
+# WebDAV Browser App
+
+This simple Flask web application provides a split-screen layout with a video player on the left and a basic browser on the right. You can load a video from a WebDAV URL and browse any website side by side.
+
+## Usage
+
+1. Install the dependencies (Flask):
+   ```bash
+   pip install Flask
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Open `http://127.0.0.1:5000` in your browser.
+4. Enter your WebDAV video URL and the website URL you want to browse.
+
+This app is provided for demonstration purposes and uses the GPL-3.0 license like the rest of the project.

--- a/WebDAVBrowser/app.py
+++ b/WebDAVBrowser/app.py
@@ -1,0 +1,10 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/WebDAVBrowser/templates/index.html
+++ b/WebDAVBrowser/templates/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>WebDAV Video Browser</title>
+  <style>
+    body, html { margin:0; padding:0; height:100%; }
+    .container { display:flex; height:100vh; }
+    .video-side, .browser-side { flex:1; display:flex; flex-direction:column; }
+    video { width:100%; height:100%; }
+    iframe { flex:1; width:100%; border:none; }
+    .controls { padding:5px; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="video-side">
+    <div class="controls">
+      <input id="video-url" type="text" placeholder="WebDAV video URL" style="width:80%" />
+      <button onclick="loadVideo()">Load Video</button>
+    </div>
+    <video id="video" controls></video>
+  </div>
+  <div class="browser-side">
+    <div class="controls">
+      <input id="browser-url" type="text" placeholder="Website URL" style="width:80%" />
+      <button onclick="loadBrowser()">Go</button>
+    </div>
+    <iframe id="browser-frame"></iframe>
+  </div>
+</div>
+<script>
+function loadVideo() {
+  var url = document.getElementById('video-url').value;
+  document.getElementById('video').src = url;
+}
+function loadBrowser() {
+  var url = document.getElementById('browser-url').value;
+  document.getElementById('browser-frame').src = url;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask app in `WebDAVBrowser/` for playing videos from a WebDAV URL and browsing websites side by side
- include HTML template and README with usage steps

## Testing
- `python3 -m py_compile WebDAVBrowser/app.py`
- `python WebDAVBrowser/app.py` *(fails: port already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6878c250c8ac8327911ca4bd9de58e79